### PR TITLE
feat(e2e): add e2e tests

### DIFF
--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -1,11 +1,7 @@
-
 import models.io.upbound.gcp.compute.v1beta1 as computev1beta1
 import models.io.upbound.platform.gcp.v1alpha1 as platformgcpv1alpha1
 
 oxr = platformgcpv1alpha1.XNetwork{**option("params").oxr} # observed composite resource
-_ocds = option("params").ocds # observed composed resources
-_dxr = option("params").dxr # desired composite resource
-dcds = option("params").dcds # desired composed resources
 params = oxr.spec.parameters
 
 _metadata = lambda name: str -> any {
@@ -47,17 +43,17 @@ computev1beta1.Subnetwork{
             privateIpGoogleAccess: True
             secondaryIpRange: [
                 {
-                ipCidrRange: "10.200.0.0/14"
-                rangeName: "pods"
+                    ipCidrRange: "10.200.0.0/14"
+                    rangeName: "pods"
                 },
                 {
-                ipCidrRange: "10.204.0.0/16"
-                rangeName: "services"
+                    ipCidrRange: "10.204.0.0/16"
+                    rangeName: "services"
                 },
             ]
         }
     }
 }
 ]
-items = _items
 
+items = _items

--- a/tests/e2etest-xnetwork/kcl.mod
+++ b/tests/e2etest-xnetwork/kcl.mod
@@ -1,0 +1,6 @@
+[package]
+name = "e2etest-xnetwork"
+version = "0.0.1"
+
+[dependencies]
+models = { path = "./model" }

--- a/tests/e2etest-xnetwork/kcl.mod.lock
+++ b/tests/e2etest-xnetwork/kcl.mod.lock
@@ -1,0 +1,12 @@
+[dependencies]
+  [dependencies.model]
+    name = "model"
+    full_name = "models_0.0.1"
+    version = "0.0.1"
+    reg = "ghcr.io"
+    repo = "kcl-lang/model"
+    oci_tag = "0.0.1"
+  [dependencies.models]
+    name = "models"
+    full_name = "models_0.0.1"
+    version = "0.0.1"

--- a/tests/e2etest-xnetwork/main.k
+++ b/tests/e2etest-xnetwork/main.k
@@ -1,0 +1,45 @@
+import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
+import models.io.upbound.gcp.v1beta1 as gcpv1beta1
+import models.io.upbound.platform.gcp.v1alpha1 as platformgcpv1alpha1
+
+_items = [
+    metav1alpha1.E2ETest{
+        metadata.name: "xnetwork"
+        spec= {
+            crossplane.autoUpgrade.channel: "Rapid"
+            defaultConditions: ["Ready"]
+            manifests: [
+                platformgcpv1alpha1.XNetwork{
+                    metadata.name: "configuration-gcp-network-e2e"
+                    spec: {
+                        parameters: {
+                            id: "configuration-gcp-network-e2e"
+                            region: "us-west2"
+                        }
+                    }
+                }
+            ]
+            extraResources: [
+                gcpv1beta1.ProviderConfig{
+                    metadata.name: "default"
+                    spec: {
+                        projectID: "crossplane-playground"
+                        credentials: {
+                            source: "Upbound"
+                            upbound: {
+                                federation: {
+                                    providerID: "projects/283222062215/locations/global/workloadIdentityPools/solutions-upbound-oidc-pool/providers/solutions-u5d-oidc-pool"
+                                    serviceAccount: "solutions-u5d-service-account@crossplane-playground.iam.gserviceaccount.com"
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+            skipDelete: False
+            timeoutSeconds: 4500
+        }
+    }
+]
+
+items= _items

--- a/tests/e2etest-xnetwork/model
+++ b/tests/e2etest-xnetwork/model
@@ -1,0 +1,1 @@
+../../.up/kcl/models


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
add e2e tests

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
```
up test run tests/* --e2e
  ✓   Parsing tests                                                                                                                                                  
  ✓   Checking dependencies
  ✓   Generating language schemas
  ✓   Building functions
  ✓   Building configuration package
  ✓   Ensuring repository exists
  ✓   Pushing function package xpkg.upbound.io/solutions/configuration-gcp-network_xnetwork
  ✓   Pushing configuration image xpkg.upbound.io/solutions/configuration-gcp-network:v0.0.0-1749570975
  ✓   Creating development control plane
  ✓   Installing package on development control plane
  ✓   Waiting for package to be ready
  ✓   Applying Extra Resources                                                                                                                                       
2025/06/10 17:57:41 Skipping update step because the root resource does not exist
2025/06/10 17:57:41 Skipping update step because the skip-delete option is set to true
2025/06/10 17:57:41 Skipping import step because the skip-import option is set to true
2025/06/10 17:57:41 Written test files: /var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xnetwork3240555497
2025/06/10 17:57:41 Running chainsaw tests at /var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xnetwork3240555497
2025/06/10 17:57:41 Loading default configuration...
2025/06/10 17:57:41 - Using test file: 00-apply.yaml
2025/06/10 17:57:41 - ApplyTimeout 5s
2025/06/10 17:57:41 - AssertTimeout 30s
2025/06/10 17:57:41 - CleanupTimeout 30s
2025/06/10 17:57:41 - DeleteTimeout 15s
2025/06/10 17:57:41 - ErrorTimeout 30s
2025/06/10 17:57:41 - ExecTimeout 5s
2025/06/10 17:57:41 - Parallel 1
2025/06/10 17:57:41 Loading tests...
2025/06/10 17:57:41 - apply (/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xnetwork3240555497/case)
2025/06/10 17:57:41 Running tests...
=== RUN   chainsaw
=== PAUSE chainsaw
=== CONT  chainsaw
=== RUN   chainsaw/apply
=== PAUSE chainsaw/apply
=== CONT  chainsaw/apply
    | 17:57:42 | apply | @chainsaw                | CREATE    | OK    | v1/Namespace @ chainsaw-vast-cat
    | 17:57:42 | apply | Apply Resources          | TRY       | BEGIN |
    | 17:57:42 | apply | Apply Resources          | APPLY     | RUN   | gcp.platform.upbound.io/v1alpha1/XNetwork @ configuration-gcp-network-e2e
    | 17:57:43 | apply | Apply Resources          | CREATE    | OK    | gcp.platform.upbound.io/v1alpha1/XNetwork @ configuration-gcp-network-e2e
    | 17:57:43 | apply | Apply Resources          | APPLY     | DONE  | gcp.platform.upbound.io/v1alpha1/XNetwork @ configuration-gcp-network-e2e
    | 17:57:43 | apply | Apply Resources          | CMD       | RUN   |
        === COMMAND
        /bin/sh -c echo "Runnning annotation script"
        ${KUBECTL} annotate xnetwork.gcp.platform.upbound.io/configuration-gcp-network-e2e upjet.upbound.io/test=true --overwrite
    | 17:57:44 | apply | Apply Resources          | SCRIPT    | LOG   |
        === STDOUT
        Runnning annotation script
        xnetwork.gcp.platform.upbound.io/configuration-gcp-network-e2e annotated
    | 17:57:44 | apply | Apply Resources          | SCRIPT    | DONE  |
    | 17:57:44 | apply | Apply Resources          | TRY       | END   |
    | 17:57:44 | apply | Assert Status Conditions | TRY       | BEGIN |
    | 17:57:45 | apply | Assert Status Conditions | ASSERT    | RUN   | gcp.platform.upbound.io/v1alpha1/XNetwork @ configuration-gcp-network-e2e
NAME                                     RESOURCE   SYNCED   READY   STATUS
XNetwork/configuration-gcp-network-e2e              -        -       
NAME                                                RESOURCE     SYNCED   READY   STATUS
XNetwork/configuration-gcp-network-e2e                           True     False   Creating: Unready resources: network, subnetwork
├─ Network/configuration-gcp-network-e2e            network      True     True    Available
└─ Subnetwork/configuration-gcp-network-e2e-vh59k   subnetwork   True     False   Creating
NAME                                                RESOURCE     SYNCED   READY   STATUS
XNetwork/configuration-gcp-network-e2e                           True     False   Creating: Unready resources: subnetwork
├─ Network/configuration-gcp-network-e2e            network      True     True    Available
└─ Subnetwork/configuration-gcp-network-e2e-vh59k   subnetwork   True     False   Creating
NAME                                                RESOURCE     SYNCED   READY   STATUS
XNetwork/configuration-gcp-network-e2e                           True     False   Creating: Unready resources: subnetwork
├─ Network/configuration-gcp-network-e2e            network      True     True    Available
└─ Subnetwork/configuration-gcp-network-e2e-vh59k   subnetwork   True     False   Creating
    | 17:58:26 | apply | Assert Status Conditions | ASSERT    | DONE  | gcp.platform.upbound.io/v1alpha1/XNetwork @ configuration-gcp-network-e2e
    | 17:58:26 | apply | Assert Status Conditions | TRY       | END   |
    | 17:58:26 | apply | @chainsaw                | CLEANUP   | SKIP  |
=== NAME  chainsaw
    | 17:58:26 | chainsaw | @chainsaw | CLEANUP   | SKIP  |
--- PASS: chainsaw (0.00s)
    --- PASS: chainsaw/apply (45.09s)
PASS
2025/06/10 17:58:26 Tests Summary:
2025/06/10 17:58:26 - Passed: 1
2025/06/10 17:58:26 - Failed: 0
2025/06/10 17:58:26 - Skipped: 0
2025/06/10 17:58:26 Skipping test 01-update.yaml
2025/06/10 17:58:26 Skipping test 02-import.yaml
2025/06/10 17:58:26 Loading default configuration...
2025/06/10 17:58:26 - Using test file: 03-delete.yaml
2025/06/10 17:58:26 - ApplyTimeout 5s
2025/06/10 17:58:26 - AssertTimeout 30s
2025/06/10 17:58:26 - CleanupTimeout 30s
2025/06/10 17:58:26 - DeleteTimeout 15s
2025/06/10 17:58:26 - ErrorTimeout 30s
2025/06/10 17:58:26 - ExecTimeout 5s
2025/06/10 17:58:26 - Parallel 1
2025/06/10 17:58:26 Loading tests...
2025/06/10 17:58:26 - delete (/var/folders/ym/wqrhc4wd0mj6b1wbkc25s0_80000gn/T/xnetwork3240555497/case)
2025/06/10 17:58:26 Running tests...
=== RUN   chainsaw
=== PAUSE chainsaw
=== CONT  chainsaw
=== RUN   chainsaw/delete
=== PAUSE chainsaw/delete
=== CONT  chainsaw/delete
    | 17:58:27 | delete | @chainsaw        | CREATE    | OK    | v1/Namespace @ chainsaw-many-silkworm
    | 17:58:27 | delete | Delete Resources | TRY       | BEGIN |
    | 17:58:27 | delete | Delete Resources | CMD       | RUN   |
        === COMMAND
        /bin/sh -c ${KUBECTL} delete xnetwork.gcp.platform.upbound.io/configuration-gcp-network-e2e --wait=false --ignore-not-found
    | 17:58:28 | delete | Delete Resources | SCRIPT    | LOG   |
        === STDOUT
        xnetwork.gcp.platform.upbound.io "configuration-gcp-network-e2e" deleted
    | 17:58:28 | delete | Delete Resources | SCRIPT    | DONE  |
    | 17:58:28 | delete | Delete Resources | TRY       | END   |
    | 17:58:28 | delete | Assert Deletion  | TRY       | BEGIN |
    | 17:58:28 | delete | Assert Deletion  | CMD       | RUN   |
        === COMMAND
        /bin/sh -c ${KUBECTL} wait --for=delete xnetwork.gcp.platform.upbound.io/configuration-gcp-network-e2e --timeout 1h15m0s
    | 17:58:29 | delete | Assert Deletion  | SCRIPT    | DONE  |
    | 17:58:29 | delete | Assert Deletion  | TRY       | END   |
    | 17:58:29 | delete | @chainsaw        | CLEANUP   | SKIP  |
=== NAME  chainsaw
    | 17:58:29 | chainsaw | @chainsaw | CLEANUP   | SKIP  |
--- PASS: chainsaw (0.00s)
    --- PASS: chainsaw/delete (2.94s)
PASS
2025/06/10 17:58:29 Tests Summary:
2025/06/10 17:58:29 - Passed: 1
2025/06/10 17:58:29 - Failed: 0
2025/06/10 17:58:29 - Skipped: 0
SUCCESS: 
SUCCESS: Tests Summary:
SUCCESS: ------------------
SUCCESS: Total Tests Executed: 1
SUCCESS: Passed tests:         1
SUCCESS: Failed tests:         0
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
